### PR TITLE
Always construct new instances of fragment presenters if presenter is…

### DIFF
--- a/judo-sdk/src/main/java/com/judopay/PaymentFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/PaymentFragment.java
@@ -15,7 +15,7 @@ public final class PaymentFragment extends BaseFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState == null) {
+        if (this.presenter == null) {
             this.presenter = new PaymentPresenter(this, JudoApiServiceFactory.getInstance(getActivity()), new AndroidScheduler(), new Gson());
         }
     }

--- a/judo-sdk/src/main/java/com/judopay/PreAuthFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/PreAuthFragment.java
@@ -15,7 +15,7 @@ public final class PreAuthFragment extends BaseFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState == null) {
+        if (this.presenter == null) {
             this.presenter = new PreAuthPresenter(this, JudoApiServiceFactory.getInstance(getActivity()), new AndroidScheduler(), new Gson());
         }
     }

--- a/judo-sdk/src/main/java/com/judopay/RegisterCardFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/RegisterCardFragment.java
@@ -19,7 +19,7 @@ public class RegisterCardFragment extends BaseFragment implements PaymentFormVie
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState == null) {
+        if (this.presenter == null) {
             this.presenter = new RegisterCardPresenter(this, JudoApiServiceFactory.getInstance(getActivity()), new AndroidScheduler(), new Gson());
         }
     }

--- a/judo-sdk/src/main/java/com/judopay/TokenPaymentFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/TokenPaymentFragment.java
@@ -15,7 +15,7 @@ public final class TokenPaymentFragment extends BaseFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState == null) {
+        if (this.presenter == null) {
             this.presenter = new TokenPaymentPresenter(this, JudoApiServiceFactory.getInstance(getActivity()), new AndroidScheduler(), new Gson());
         }
     }

--- a/judo-sdk/src/main/java/com/judopay/TokenPreAuthFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/TokenPreAuthFragment.java
@@ -15,7 +15,7 @@ public class TokenPreAuthFragment extends BaseFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (savedInstanceState == null) {
+        if (this.presenter == null) {
             this.presenter = new TokenPreAuthPresenter(this, JudoApiServiceFactory.getInstance(getActivity()), new AndroidScheduler(), new Gson());
         }
     }


### PR DESCRIPTION
… null, to avoid exception when activity is killed in background.