### PR TITLE
Maestro & token payment bug fixes

### DIFF
--- a/judo-sdk/src/androidTest/java/com/judopay/ui/TokenPaymentFormTest.java
+++ b/judo-sdk/src/androidTest/java/com/judopay/ui/TokenPaymentFormTest.java
@@ -29,12 +29,13 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withHint;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.judopay.model.CardType.AMEX;
 import static com.judopay.model.CardType.MAESTRO;
+import static com.judopay.model.CardType.VISA;
 import static com.judopay.ui.util.ViewMatchers.isDisabled;
 import static com.judopay.ui.util.ViewMatchers.isNotDisplayed;
+import static com.judopay.ui.util.ViewMatchers.isOpaque;
 import static com.judopay.ui.util.ViewMatchers.withTextInputHint;
-import static com.judopay.model.CardType.AMEX;
-import static com.judopay.model.CardType.VISA;
 
 @LargeTest
 @RunWith(AndroidJUnit4.class)
@@ -121,6 +122,14 @@ public class TokenPaymentFormTest {
     }
 
     @Test
+    public void shouldShowCardTypeImageAsFullyOpaque() {
+        activityTestRule.launchActivity(getIntent(VISA));
+
+        onView(withId(R.id.card_type_view))
+                .check(matches(isOpaque()));
+    }
+
+    @Test
     public void shouldNotShowMaestroFieldsWhenMaestroTokenPayment() {
         Judo.setAvsEnabled(false);
 
@@ -135,6 +144,9 @@ public class TokenPaymentFormTest {
 
         onView(withId(R.id.issue_number_entry_view))
                 .check(matches(isNotDisplayed()));
+
+        onView(withId(R.id.payment_button))
+                .check(matches(isDisplayed()));
     }
 
     @Test

--- a/judo-sdk/src/androidTest/java/com/judopay/ui/util/ViewMatchers.java
+++ b/judo-sdk/src/androidTest/java/com/judopay/ui/util/ViewMatchers.java
@@ -48,6 +48,20 @@ public class ViewMatchers {
         };
     }
 
+    public static Matcher<View> isOpaque() {
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("is opaque");
+            }
+
+            @Override
+            public boolean matchesSafely(View view) {
+                return view.getAlpha() == 1.0f;
+            }
+        };
+    }
+
     public static Matcher<View> isDisabled() {
         return new TypeSafeMatcher<View>() {
             @Override

--- a/judo-sdk/src/main/java/com/judopay/PaymentFormValidation.java
+++ b/judo-sdk/src/main/java/com/judopay/PaymentFormValidation.java
@@ -119,7 +119,7 @@ public class PaymentFormValidation {
 
             StartDateAndIssueNumberValidation startDateAndIssueNumberValidation = new StartDateAndIssueNumberValidation(paymentForm, cardType);
 
-            boolean maestroValid = !maestroCardType ||
+            boolean maestroValid = paymentForm.isTokenCard() || !maestroCardType ||
                     (startDateAndIssueNumberValidation.isStartDateEntryComplete() && !startDateAndIssueNumberValidation.isShowStartDateError())
                             && startDateAndIssueNumberValidation.isIssueNumberValid();
 

--- a/judo-sdk/src/main/java/com/judopay/view/CardNumberEntryView.java
+++ b/judo-sdk/src/main/java/com/judopay/view/CardNumberEntryView.java
@@ -91,6 +91,7 @@ public class CardNumberEntryView extends RelativeLayout {
     public void setTokenizedNumber(String lastFour) {
         cardNumberEditText.setEnabled(false);
         cardNumberEditText.setText(getContext().getString(R.string.token_card_number, lastFour));
+        cardTypeImageView.setAlpha(1.0f);
     }
 
     public void setError(@StringRes int message, boolean show) {


### PR DESCRIPTION
Maestro cards should be able to make token payments without start date and issue number.

Show card image as fully opaque when a token payment is made + add tests for card image opacity