### PR TITLE
Amex card entry crashing bug fix

### DIFF
--- a/judo-sdk/src/androidTest/java/com/judopay/ui/CardNumberEntryTest.java
+++ b/judo-sdk/src/androidTest/java/com/judopay/ui/CardNumberEntryTest.java
@@ -1,0 +1,81 @@
+package com.judopay.ui;
+
+import android.content.Intent;
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.rule.ActivityTestRule;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import com.judopay.Judo;
+import com.judopay.JudoOptions;
+import com.judopay.PaymentActivity;
+import com.judopay.R;
+import com.judopay.model.Currency;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+@LargeTest
+public class CardNumberEntryTest {
+
+    @Rule
+    public ActivityTestRule<PaymentActivity> activityTestRule = new ActivityTestRule<>(PaymentActivity.class, false, false);
+
+    @Test
+    public void shouldHaveAmexCardNumberFormattingWhenAmexCardEntered() {
+        Judo.setAmexEnabled(true);
+
+        activityTestRule.launchActivity(getIntent());
+
+        onView(ViewMatchers.withId(R.id.card_number_edit_text))
+                .perform(typeText("340000432128428"))
+                .check(matches(withText("3400 004321 28428")));
+    }
+
+    @Test
+    public void shouldHaveNormalCardNumberFormattingWhenVisaCardNumberEntered() {
+        activityTestRule.launchActivity(getIntent());
+
+        onView(withId(R.id.card_number_edit_text))
+                .perform(typeText("4976000000003436"))
+                .check(matches(withText("4976 0000 0000 3436")));
+    }
+
+    @Test
+    public void shouldRestrictCardNumberLengthToSixteenDigitsWhenVisa() {
+        activityTestRule.launchActivity(getIntent());
+
+        onView(withId(R.id.card_number_edit_text))
+                .perform(typeText("49760000000034360"))
+                .check(matches(withText("4976 0000 0000 3436")));
+    }
+
+    @Test
+    public void shouldRestrictCardNumberLengthToFifteenDigitsWhenAmex() {
+        activityTestRule.launchActivity(getIntent());
+
+        onView(withId(R.id.card_number_edit_text))
+                .perform(typeText("3400004321284280"))
+                .check(matches(withText("3400 004321 28428")));
+    }
+
+    private Intent getIntent() {
+        Intent intent = new Intent();
+
+        intent.putExtra(Judo.JUDO_OPTIONS, new JudoOptions.Builder()
+                .setJudoId("100407196")
+                .setAmount("0.99")
+                .setCurrency(Currency.GBP)
+                .setConsumerRef(UUID.randomUUID().toString())
+                .build());
+        return intent;
+    }
+
+}

--- a/judo-sdk/src/androidTest/java/com/judopay/ui/PaymentFormTest.java
+++ b/judo-sdk/src/androidTest/java/com/judopay/ui/PaymentFormTest.java
@@ -38,26 +38,6 @@ public class PaymentFormTest {
     public ActivityTestRule<PaymentActivity> activityTestRule = new ActivityTestRule<>(PaymentActivity.class, false, false);
 
     @Test
-    public void shouldHaveAmexCardNumberFormattingWhenAmexCardEntered() {
-        Judo.setAmexEnabled(true);
-
-        activityTestRule.launchActivity(getIntent());
-
-        onView(ViewMatchers.withId(R.id.card_number_edit_text))
-                .perform(typeText("340000432128428"))
-                .check(matches(withText("3400 004321 28428")));
-    }
-
-    @Test
-    public void shouldHaveNormalCardNumberFormattingWhenVisaCardNumberEntered() {
-        activityTestRule.launchActivity(getIntent());
-
-        onView(withId(R.id.card_number_edit_text))
-                .perform(typeText("4976000000003436"))
-                .check(matches(withText("4976 0000 0000 3436")));
-    }
-
-    @Test
     public void shouldDisplayCidvHintWhenAmexCardNumberEntered() {
         Judo.setAmexEnabled(true);
 

--- a/judo-sdk/src/main/java/com/judopay/BaseFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/BaseFragment.java
@@ -24,7 +24,7 @@ import static android.app.PendingIntent.FLAG_ONE_SHOT;
 abstract class BaseFragment extends Fragment implements TransactionCallbacks, CardEntryListener {
 
     private static final String TAG_PAYMENT_FORM = "CardEntryFragment";
-    public static final String TAG_3DS_DIALOG = "3dSecureDialog";
+    private static final String TAG_3DS_DIALOG = "3dSecureDialog";
 
     private View progressBar;
     private TextView progressText;

--- a/judo-sdk/src/main/java/com/judopay/PaymentFragment.java
+++ b/judo-sdk/src/main/java/com/judopay/PaymentFragment.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 import android.view.View;
 
 import com.google.gson.Gson;
-import com.judopay.api.JudoApiServiceFactory;
 import com.judopay.arch.AndroidScheduler;
 import com.judopay.model.Card;
 

--- a/judo-sdk/src/main/java/com/judopay/api/ClientDetailsSerializer.java
+++ b/judo-sdk/src/main/java/com/judopay/api/ClientDetailsSerializer.java
@@ -15,7 +15,7 @@ import java.util.Map;
 class ClientDetailsSerializer implements JsonSerializer<ClientDetails> {
 
     private final Context context;
-    private Gson gson;
+    private final Gson gson;
 
     public ClientDetailsSerializer(Context context) {
         this.context = context;

--- a/judo-sdk/src/main/java/com/judopay/model/CardDate.java
+++ b/judo-sdk/src/main/java/com/judopay/model/CardDate.java
@@ -15,7 +15,7 @@ public class CardDate {
         this.year = getYear(splitCardDate);
     }
 
-    public int getYear(String year) {
+    private int getYear(String year) {
         if (!isValidDate(year)) {
             return 0;
         }
@@ -23,7 +23,7 @@ public class CardDate {
         return 2000 + Integer.parseInt(year.substring(2, 4));
     }
 
-    public int getMonth(String month) {
+    private int getMonth(String month) {
         if (!isValidDate(month)) {
             return 0;
         }

--- a/judo-sdk/src/main/java/com/judopay/view/CardNumberEntryView.java
+++ b/judo-sdk/src/main/java/com/judopay/view/CardNumberEntryView.java
@@ -75,6 +75,8 @@ public class CardNumberEntryView extends RelativeLayout {
         switch (type) {
             case CardType.AMEX:
                 setMaxLength(17);
+                break;
+
             default:
                 setMaxLength(19);
         }

--- a/judo-sdk/src/main/java/com/judopay/view/CardNumberFormattingTextWatcher.java
+++ b/judo-sdk/src/main/java/com/judopay/view/CardNumberFormattingTextWatcher.java
@@ -51,7 +51,7 @@ class CardNumberFormattingTextWatcher implements TextWatcher {
                         string.delete(i, i + 1);
                     }
                 }
-            } else if (SPACE_CHAR == pattern.charAt(i)) {
+            } else if (i < pattern.length() && SPACE_CHAR == pattern.charAt(i)) {
                 // there is a space in the pattern but not in the string
                 if(!(before == 1 && count == 0)) {
                     string.insert(i, SPACE);


### PR DESCRIPTION
Due to a missing break statement, when entering an amex card number the max character length for the field was not being properly set, this has now been capped at 15 digits.