### PR TITLE
Replace JodaTime library

### DIFF
--- a/judo-sdk/build.gradle
+++ b/judo-sdk/build.gradle
@@ -24,7 +24,7 @@ android {
         consumerProguardFiles 'proguard-rules.pro'
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
 
-        productFlavors { }
+        productFlavors {}
     }
 
     buildTypes {
@@ -74,6 +74,8 @@ dependencies {
 
     compile 'com.android.support:appcompat-v7:23.2.0'
     compile 'com.android.support:design:23.2.0'
+
+    compile 'fr.turri:jISO8601:0.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/judo-sdk/build.gradle
+++ b/judo-sdk/build.gradle
@@ -72,7 +72,6 @@ dependencies {
 
     compile 'io.reactivex:rxandroid:0.23.0'
 
-    compile 'joda-time:joda-time:2.8.2'
     compile 'com.android.support:appcompat-v7:23.2.0'
     compile 'com.android.support:design:23.2.0'
 

--- a/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
+++ b/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
@@ -37,14 +37,13 @@ class DateJsonDeserializer implements JsonDeserializer<Date> {
      * @return the parsed date
      * @throws ParseException
      */
-    public Date iso8601ToDate(final String date) throws ParseException {
-        String s = date.replace("Z", "+00:00");
+    public Date iso8601ToDate(String date) throws ParseException {
         try {
-            s = s.substring(0, 22) + s.substring(23);  // to get rid of the ":"
+            date = date.substring(0, 22) + date.substring(23);  // to remove the ":"
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException("Invalid length", 0);
         }
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US).parse(s);
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US).parse(date);
     }
 
 }

--- a/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
+++ b/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
@@ -6,10 +6,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.Locale;
+
+import fr.turri.jiso8601.Iso8601Deserializer;
 
 import static com.judopay.arch.TextUtil.isEmpty;
 
@@ -20,32 +19,10 @@ class DateJsonDeserializer implements JsonDeserializer<Date> {
         String date = json.getAsString();
 
         if (!isEmpty(date)) {
-            try {
-                return iso8601ToDate(date);
-            } catch (ParseException e) {
-                return null;
-            }
+            return Iso8601Deserializer.toDate(date);
         } else {
             return null;
         }
-    }
-
-    /**
-     * Transforms an ISO-8601 String to a Date
-     *
-     * @param date the date as defined in ISO-8601 format
-     * @return the parsed date
-     * @throws ParseException
-     */
-    public Date iso8601ToDate(String date) throws ParseException {
-        try {
-            int timezoneSeparatorIndex = date.lastIndexOf(':');
-            // to remove the last ":"
-            date = date.substring(0, timezoneSeparatorIndex) + timezoneSeparatorIndex;
-        } catch (IndexOutOfBoundsException e) {
-            throw new ParseException("Invalid length", 0);
-        }
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSX", Locale.US).parse(date);
     }
 
 }

--- a/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
+++ b/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
@@ -39,11 +39,13 @@ class DateJsonDeserializer implements JsonDeserializer<Date> {
      */
     public Date iso8601ToDate(String date) throws ParseException {
         try {
-            date = date.substring(0, 22) + date.substring(23);  // to remove the ":"
+            int timezoneSeparatorIndex = date.lastIndexOf(':');
+            // to remove the last ":"
+            date = date.substring(0, timezoneSeparatorIndex) + timezoneSeparatorIndex;
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException("Invalid length", 0);
         }
-        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US).parse(date);
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSX", Locale.US).parse(date);
     }
 
 }

--- a/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
+++ b/judo-sdk/src/main/java/com/judopay/api/DateJsonDeserializer.java
@@ -5,10 +5,11 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
-import org.joda.time.DateTime;
-
 import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import static com.judopay.arch.TextUtil.isEmpty;
 
@@ -19,11 +20,31 @@ class DateJsonDeserializer implements JsonDeserializer<Date> {
         String date = json.getAsString();
 
         if (!isEmpty(date)) {
-            DateTime dateTime = new DateTime(date);
-            return dateTime.toDate();
+            try {
+                return iso8601ToDate(date);
+            } catch (ParseException e) {
+                return null;
+            }
         } else {
             return null;
         }
+    }
+
+    /**
+     * Transforms a ISO 8601 string to a Date
+     *
+     * @param date the date as defined in ISO-8601 format
+     * @return the parsed date
+     * @throws ParseException
+     */
+    public Date iso8601ToDate(final String date) throws ParseException {
+        String s = date.replace("Z", "+00:00");
+        try {
+            s = s.substring(0, 22) + s.substring(23);  // to get rid of the ":"
+        } catch (IndexOutOfBoundsException e) {
+            throw new ParseException("Invalid length", 0);
+        }
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX", Locale.US).parse(s);
     }
 
 }

--- a/judo-sdk/src/main/java/com/judopay/model/CardDate.java
+++ b/judo-sdk/src/main/java/com/judopay/model/CardDate.java
@@ -65,16 +65,16 @@ public class CardDate {
     }
 
     public boolean isInsideAllowedDateRange() {
-        Calendar now = Calendar.getInstance();
-        now.setTime(new Date());
-
-        Calendar minDate = (Calendar) now.clone();
+        Calendar minDate = Calendar.getInstance();
         minDate.set(YEAR, minDate.get(YEAR) - 10);
 
-        Calendar maxDate = (Calendar) now.clone();
-        minDate.set(YEAR, maxDate.get(YEAR) + 10);
+        Calendar maxDate = Calendar.getInstance();
+        maxDate.set(YEAR, maxDate.get(YEAR) + 10);
 
-        return now.after(minDate) && now.before(maxDate);
+        Calendar cardDate = Calendar.getInstance();
+        cardDate.set(year, month - 1, 1);
+
+        return cardDate.after(minDate) && cardDate.before(maxDate);
     }
 
     private boolean isValidDate(String date) {

--- a/judo-sdk/src/main/java/com/judopay/model/CardDate.java
+++ b/judo-sdk/src/main/java/com/judopay/model/CardDate.java
@@ -1,8 +1,11 @@
 package com.judopay.model;
 
-import org.joda.time.DateTime;
-import org.joda.time.LocalDate;
-import org.joda.time.YearMonth;
+import java.util.Calendar;
+import java.util.Date;
+
+import static java.util.Calendar.DATE;
+import static java.util.Calendar.MONTH;
+import static java.util.Calendar.YEAR;
 
 public class CardDate {
 
@@ -32,47 +35,50 @@ public class CardDate {
     }
 
     public boolean isBeforeToday() {
-        if(year == 0 && month == 0) {
+        if (year == 0 || month == 0) {
             return false;
         }
 
-        DateTime midnightToday = getTimeAtStartOfDay();
-        LocalDate localDate = getLocalDate(month, year);
+        Calendar cardDate = Calendar.getInstance();
+        cardDate.set(year, month - 1, 1);
 
-        return localDate.isBefore(midnightToday.toLocalDate());
+        Calendar now = Calendar.getInstance();
+        now.setTime(new Date());
+
+        return cardDate.before(now);
     }
 
     public boolean isAfterToday() {
-        if(year == 0 && month == 0) {
+        if (year == 0 || month == 0) {
             return false;
         }
 
-        LocalDate expiryLocalDate = getLocalDate(month, year);
-        DateTime startOfDay = getTimeAtStartOfDay();
+        Calendar cardDate = Calendar.getInstance();
+        cardDate.set(YEAR, year);
+        cardDate.set(MONTH, month - 1);
+        cardDate.set(DATE, cardDate.getActualMaximum(Calendar.DAY_OF_MONTH));
 
-        return expiryLocalDate.isAfter(startOfDay.toLocalDate());
+        Calendar now = Calendar.getInstance();
+        now.setTime(new Date());
+
+        return cardDate.after(now);
     }
 
     public boolean isInsideAllowedDateRange() {
-        DateTime startOfDay = getTimeAtStartOfDay();
+        Calendar now = Calendar.getInstance();
+        now.setTime(new Date());
 
-        LocalDate localDate = getLocalDate(month, year);
-        LocalDate minDate = getLocalDate(month, startOfDay.getYear() - 10);
-        LocalDate maxDate = getLocalDate(month, startOfDay.getYear() + 10);
+        Calendar minDate = (Calendar) now.clone();
+        minDate.set(YEAR, minDate.get(YEAR) - 10);
 
-        return localDate.isAfter(minDate) && localDate.isBefore(maxDate);
+        Calendar maxDate = (Calendar) now.clone();
+        minDate.set(YEAR, maxDate.get(YEAR) + 10);
+
+        return now.after(minDate) && now.before(maxDate);
     }
 
     private boolean isValidDate(String date) {
         return date.matches("(?:0[1-9]|1[0-2])[0-9]{2}");
-    }
-
-    private DateTime getTimeAtStartOfDay() {
-        return new DateTime().withTimeAtStartOfDay();
-    }
-
-    private LocalDate getLocalDate(int month, int year) {
-        return new YearMonth(year, month).toLocalDate(1);
     }
 
 }

--- a/judo-sdk/src/main/java/com/judopay/secure3d/ThreeDSecureDialogFragment2.java
+++ b/judo-sdk/src/main/java/com/judopay/secure3d/ThreeDSecureDialogFragment2.java
@@ -1,6 +1,0 @@
-package com.judopay.secure3d;
-
-public class ThreeDSecureDialogFragment2 {
-
-
-}

--- a/judo-sdk/src/test/java/com/judopay/api/DateJsonDeserializerTest.java
+++ b/judo-sdk/src/test/java/com/judopay/api/DateJsonDeserializerTest.java
@@ -38,13 +38,33 @@ public class DateJsonDeserializerTest {
     }
 
     @Test
-    public void shouldDeserializeDateWithTimezone() {
+    public void shouldDeserializeDateWith3DigitMillisecondPrecision() {
+        DateJsonDeserializer deserializer = new DateJsonDeserializer();
+
+        when(jsonElement.getAsString()).thenReturn("2016-03-24T09:55:28.329+00:00");
+        Date date = deserializer.deserialize(jsonElement, type, jsonDeserializationContext);
+
+        assertThat(date.getTime(), is(1458813328032L));
+    }
+
+    @Test
+    public void shouldDeserializeDateWithPositiveTimezoneOffset() {
         DateJsonDeserializer deserializer = new DateJsonDeserializer();
 
         when(jsonElement.getAsString()).thenReturn("2016-03-24T09:55:28.3299+01:00");
         Date date = deserializer.deserialize(jsonElement, type, jsonDeserializationContext);
 
         assertThat(date.getTime(), is(1458809728329L));
+    }
+
+    @Test
+    public void shouldDeserializeDateWithNegativeTimezoneOffset() {
+        DateJsonDeserializer deserializer = new DateJsonDeserializer();
+
+        when(jsonElement.getAsString()).thenReturn("2016-03-24T09:55:28.3299-02:00");
+        Date date = deserializer.deserialize(jsonElement, type, jsonDeserializationContext);
+
+        assertThat(date.getTime(), is(1458820528329L));
     }
 
 }

--- a/judo-sdk/src/test/java/com/judopay/api/DateJsonDeserializerTest.java
+++ b/judo-sdk/src/test/java/com/judopay/api/DateJsonDeserializerTest.java
@@ -44,7 +44,7 @@ public class DateJsonDeserializerTest {
         when(jsonElement.getAsString()).thenReturn("2016-03-24T09:55:28.329+00:00");
         Date date = deserializer.deserialize(jsonElement, type, jsonDeserializationContext);
 
-        assertThat(date.getTime(), is(1458813328032L));
+        assertThat(date.getTime(), is(1458813328329L));
     }
 
     @Test

--- a/judo-sdk/src/test/java/com/judopay/api/DateJsonDeserializerTest.java
+++ b/judo-sdk/src/test/java/com/judopay/api/DateJsonDeserializerTest.java
@@ -1,0 +1,50 @@
+package com.judopay.api;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Type;
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DateJsonDeserializerTest {
+
+    @Mock
+    JsonElement jsonElement;
+
+    @Mock
+    Type type;
+
+    @Mock
+    JsonDeserializationContext jsonDeserializationContext;
+
+    @Test
+    public void shouldDeserializeDate() {
+        DateJsonDeserializer deserializer = new DateJsonDeserializer();
+
+        when(jsonElement.getAsString()).thenReturn("2016-03-24T09:55:28.3299+00:00");
+        Date date = deserializer.deserialize(jsonElement, type, jsonDeserializationContext);
+
+        assertThat(date.getTime(), is(1458813328329L));
+    }
+
+    @Test
+    public void shouldDeserializeDateWithTimezone() {
+        DateJsonDeserializer deserializer = new DateJsonDeserializer();
+
+        when(jsonElement.getAsString()).thenReturn("2016-03-24T09:55:28.3299+01:00");
+        Date date = deserializer.deserialize(jsonElement, type, jsonDeserializationContext);
+
+        assertThat(date.getTime(), is(1458809728329L));
+    }
+
+}

--- a/judo-sdk/src/test/java/com/judopay/model/CardDateTest.java
+++ b/judo-sdk/src/test/java/com/judopay/model/CardDateTest.java
@@ -14,6 +14,18 @@ public class CardDateTest {
     }
 
     @Test
+    public void dateShouldBeBeforeToday() {
+        CardDate cardDate = new CardDate("12/12");
+        assertThat(cardDate.isBeforeToday(), is(true));
+    }
+
+    @Test
+    public void dateShouldBeAfterToday() {
+        CardDate cardDate = new CardDate("12/30");
+        assertThat(cardDate.isAfterToday(), is(true));
+    }
+
+    @Test
     public void dateShouldBeOutsideAllowedRangeWhenOlderThanTenYearsAgo() {
         CardDate cardDate = new CardDate("12/05");
         assertThat(cardDate.isInsideAllowedDateRange(), is(false));

--- a/judo-sdk/src/test/java/com/judopay/model/CardDateTest.java
+++ b/judo-sdk/src/test/java/com/judopay/model/CardDateTest.java
@@ -26,6 +26,12 @@ public class CardDateTest {
     }
 
     @Test
+    public void shouldBeInsideAllowedRange() {
+        CardDate cardDate = new CardDate("12/16");
+        assertThat(cardDate.isInsideAllowedDateRange(), is(true));
+    }
+
+    @Test
     public void dateShouldBeOutsideAllowedRangeWhenOlderThanTenYearsAgo() {
         CardDate cardDate = new CardDate("12/05");
         assertThat(cardDate.isInsideAllowedDateRange(), is(false));


### PR DESCRIPTION
- Use SimpleDateFormatter for parsing dates returned from partner API
- Use Calendar to replace JodaTime for card date expiry date/start date date calculations